### PR TITLE
v0.3.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnfoldMakie"
 uuid = "69a5ce3b-64fb-4f22-ae69-36dd4416af2a"
 authors = ["Benedikt Ehinger","Vladimir Mikheev", "Daniel Baumgartner", "Sören Döring", "Niklas Gärtner"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 AlgebraOfGraphics = "cbdf2221-f076-402e-a563-3d30da359d67"
@@ -34,7 +34,7 @@ GridLayoutBase = "0.9"
 ImageFiltering = "0.7"
 Makie = "0.17,0.18,0.19"
 TopoPlots = "0.1"
-Unfold = "0.3, 0.4, 0.5"
+Unfold = "0.3, 0.4, 0.5, 0.6"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
- Bugfix Topoplotseries regarding missing labels column
- general code formatting improved
- fix bug in parallel coordinates
- Bugfix butterfly plot where it was not using Topoplots.NullInterpolator, but the buggy UnfoldMakie.NullInterpolator. remove the latter.
- compat bump with breaking Unfold 0.6 release