### PR TITLE
Refactoring of topo_series

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,26 +1,24 @@
 # This CITATION.cff file was generated with cffinit.
 # Visit https://bit.ly/cffinit to generate yours today!
 
-cff-version: 1.2.0
-title: UnfoldMakie.jl
+cff-version: 1.2.1
+title: 'UnfoldMakie.jl: EEG/ERP visualization package'
 message: 'If you use this page, please cite it as below.'
 type: software
+journal: 'Journal of Open Source Software'
+volume : 10
+number: 105
+pages: 7560
 authors:
 - given-names: Vladimir
   family-names: Mikheev
   orcid: 'https://orcid.org/0000-0002-4738-6655'
-- given-names: Sören
-  family-names: Döring
-- given-names: Niklas
-  family-names: Gärtner
-- given-names: Daniel
-  family-names: Baumgartner
 - given-names: Benedikt
   family-names: Ehinger
   orcid: 'https://orcid.org/0000-0002-6276-3332'
 identifiers:
   - type: doi
-    value: 10.5281/zenodo.14500860
+    value: https://doi.org/10.21105/joss.07560
 repository-code: 'https://github.com/unfoldtoolbox/UnfoldMakie.jl'
 version: 0.5.10
-date-released: '2023-10-24'
+date-released: '2025-01-10'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://unfoldtoolbox.github.io/UnfoldMakie.jl/dev)
 [![Build Status](https://github.com/unfoldtoolbox/UnfoldMakie.jl/workflows/CI/badge.svg)](https://github.com/unfoldtoolbox/UnfoldMakie.jl/actions)
 [![Coverage](https://codecov.io/gh/behinger/UnfoldMakie.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/behinger/UnfoldMakie.jl)
+
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14500860.svg)](https://doi.org/10.5281/zenodo.14192333)
+[![DOI](https://joss.theoj.org/papers/10.21105/joss.07560/status.svg)](https://doi.org/10.21105/joss.07560)
+
 
 
 |rERP|EEG visualisation|EEG Simulations|BIDS pipeline|Decode EEG data|Statistical testing|

--- a/src/UnfoldMakie.jl
+++ b/src/UnfoldMakie.jl
@@ -52,6 +52,7 @@ include("supportive_defaults.jl")
 
 include("eeg_series.jl")
 include("plot_topoplotseries.jl")
+include("toposeries_support.jl")
 
 include("plot_erp.jl")
 include("plot_butterfly.jl")

--- a/src/eeg_series.jl
+++ b/src/eeg_series.jl
@@ -38,7 +38,7 @@ end
         fig,
         data_inp::Union{<:Observable,<:AbstractMatrix};
         layout = nothing,
-        xlabels = nothing, # can be a vector too
+        xlabels = nothing,
         labels = nothing,
         rasterize_heatmaps = true,
         interactive_scatter = nothing,
@@ -54,6 +54,11 @@ The function takes the `combinefun = mean` over the `:time` column of `data`.
 - `fig` \\
     Figure object. \\
 - `data::Union{<:Observable,<:AbstractMatrix}`\\
+    Matrix with size = (n_channel, n_topoplots).
+- `layout::Vector{Tuple{Int64, Int64}}`\\
+    Vector of tuples with coordinates for each topoplot.
+- `xlabels::Vector{String}`\\
+    Vector of xlabels for each topoplot. 
 - `topo_axis::NamedTuple = (;)`\\
     Here you can flexibly change configurations of the topoplot axis.\\
     To see all options just type `?Axis` in REPL.\\
@@ -62,6 +67,8 @@ The function takes the `combinefun = mean` over the `:time` column of `data`.
     Here you can flexibly change configurations of the topoplot interoplation.\\
     To see all options just type `?Topoplot.topoplot` in REPL.\\
     Defaults: $(supportive_defaults(:topo_default_attributes)).
+- `positions::Vector{Point{2, Float32}}`\\
+    Channel positions. The list of x and y positions for all unique electrodes. 
 
 **Return Value:** `Tuple{Figure, Vector{Any}}`.
 """

--- a/src/plot_topoplotseries.jl
+++ b/src/plot_topoplotseries.jl
@@ -150,7 +150,6 @@ function plot_topoplotseries!(
     )
     config_kwargs!(config; kwargs...)  #add the user specified once more, just if someone specifies the xlabel manually  
     # overkill as we would only need to check the xlabel ;)
-    @debug typeof(to_value(xlabels))
     ftopo, axlist, colorrange = eeg_topoplot_series!(
         f[1, 1],
         data_row;
@@ -181,67 +180,4 @@ function plot_topoplotseries!(
 
     apply_layout_settings!(config; fig = f, ax = ax)
     return f
-end
-
-function row_col_management(n_topoplots, nrows, config)
-    if :layout ∈ keys(config.mapping)
-        n_cols = Int(ceil(sqrt(n_topoplots)))
-        n_rows = Int(ceil(n_topoplots / n_cols))
-    else
-        n_rows = nrows
-        if 0 > n_topoplots / nrows
-            @warn "Impossible number of rows, set to 1 row"
-            n_rows = 1
-        elseif n_topoplots / nrows < 1
-            @warn "Impossible number of rows, set to $(n_topoplots) rows"
-        end
-        n_cols = Int(ceil(n_topoplots / n_rows))
-    end
-    col_coord = repeat(1:n_cols, outer = n_rows)[1:n_topoplots]
-    row_coord = repeat(1:n_rows, inner = n_cols)[1:n_topoplots]
-    return row_coord, col_coord
-end
-
-function bins_estimation(
-    continous_value;
-    bin_width = nothing,
-    bin_num = nothing,
-    cat_or_cont_columns = "cont",
-)
-    c_min = minimum(continous_value)
-    c_max = maximum(continous_value)
-    if (!isnothing(bin_width) && !isnothing(bin_num))
-        error("Ambigious parameters: specify only `bin_width` or `bin_num`.")
-    elseif (isnothing(bin_width) && isnothing(bin_num) && cat_or_cont_columns == "cont")
-        error(
-            "You haven't specified `bin_width` or `bin_num`. Such option is available only with categorical `mapping.col` or `mapping.row`.",
-        )
-    end
-    if isnothing(bin_width)
-        bins = range(; start = c_min, length = bin_num + 1, stop = c_max)
-    else
-        bins = range(; start = c_min, step = bin_width, stop = c_max)
-    end
-    return bins
-end
-
-function number_of_topoplots(
-    df::DataFrame;
-    bin_width = nothing,
-    bin_num = nothing,
-    bins,
-    mapping = config.mapping,
-)
-    if !isnothing(bin_width) | !isnothing(bin_num)
-        if typeof(df[:, mapping.col]) == Vector{String}
-            error(
-                "Parameters `bin_width` or `bin_num` are only allowed with continonus `mapping.col` or `mapping.row`, while you specifed categorical.",
-            )
-        end
-        cont_new = cut(df[:, mapping.col], bins; extend = true)
-        n = length(unique(cont_new))
-    else
-        n = length(unique(df[:, mapping.col]))
-    end
-    return n
 end

--- a/src/plot_topoplotseries.jl
+++ b/src/plot_topoplotseries.jl
@@ -28,7 +28,7 @@ Multiple miniature topoplots in regular distances.
 - `col_labels::Bool`, `row_labels::Bool = true`\\
     Shows column and row labels for categorical values. 
 - `positions::Vector{Point{2, Float32}} = nothing`\\
-    Specify channel positions. Requires the list of x and y positions for all unique electrode.
+    Specify channel positions. Requires the list of x and y positions for all unique electrodes.
  - `labels::Vector{String} = nothing`\\
     Show labels for each electrode.
 - `interactive_scatter = nothing`\\
@@ -48,8 +48,7 @@ Multiple miniature topoplots in regular distances.
     Here you can flexibly change configurations of the topoplot interoplation.\\
     To see all options just type `?Topoplot.topoplot` in REPL.\\
     Defaults: $(supportive_defaults(:topo_default_attributes))
-Code description:
-- 
+
 $(_docstring(:topoplotseries))
 
 **Return Value:** `Figure` displaying the Topoplot series.
@@ -97,7 +96,6 @@ function plot_topoplotseries!(
     # resolve columns with data
     config.mapping = resolve_mappings(to_value(data), config.mapping)
 
-    #data_copy = deepcopy(to_value(data)) # deepcopy prevents overwriting initial data
     cat_or_cont_columns =
         @lift eltype($data[!, config.mapping.col]) <: Number ? "cont" : "cat"
     if to_value(cat_or_cont_columns) == "cat"
@@ -152,7 +150,7 @@ function plot_topoplotseries!(
     )
     config_kwargs!(config; kwargs...)  #add the user specified once more, just if someone specifies the xlabel manually  
     # overkill as we would only need to check the xlabel ;)
-
+    @debug typeof(to_value(xlabels))
     ftopo, axlist, colorrange = eeg_topoplot_series!(
         f[1, 1],
         data_row;

--- a/src/topo_color.jl
+++ b/src/topo_color.jl
@@ -57,10 +57,10 @@ function cart2pol(x, y)
     return θ, r
 end
 
-function extract_colorrange(data_mean, y)
+function extract_colorrange(data_mean)
     # aggregate the data over time bins
     # using same colormap + contour levels for all plots
-    (q_min, q_max) = Statistics.quantile(data_mean[:, y], [0.001, 0.999])
+    (q_min, q_max) = Statistics.quantile(data_mean, [0.001, 0.999])
     # make them symmetrical
     q_min = q_max = max(abs(q_min), abs(q_max))
     q_min = -q_min

--- a/src/toposeries_support.jl
+++ b/src/toposeries_support.jl
@@ -1,0 +1,87 @@
+function row_col_management(n_topoplots, nrows, config)
+    if :layout ∈ keys(config.mapping)
+        n_cols = Int(ceil(sqrt(n_topoplots)))
+        n_rows = Int(ceil(n_topoplots / n_cols))
+    else
+        n_rows = nrows
+        if 0 > n_topoplots / nrows
+            @warn "Impossible number of rows, set to 1 row"
+            n_rows = 1
+        elseif n_topoplots / nrows < 1
+            @warn "Impossible number of rows, set to $(n_topoplots) rows"
+        end
+        n_cols = Int(ceil(n_topoplots / n_rows))
+    end
+    col_coord = repeat(1:n_cols, outer = n_rows)[1:n_topoplots]
+    row_coord = repeat(1:n_rows, inner = n_cols)[1:n_topoplots]
+    return row_coord, col_coord
+end
+
+function bins_estimation(
+    continous_value;
+    bin_width = nothing,
+    bin_num = nothing,
+    cat_or_cont_columns = "cont",
+)
+    c_min = minimum(continous_value)
+    c_max = maximum(continous_value)
+    if (!isnothing(bin_width) && !isnothing(bin_num))
+        error("Ambigious parameters: specify only `bin_width` or `bin_num`.")
+    elseif (isnothing(bin_width) && isnothing(bin_num) && cat_or_cont_columns == "cont")
+        error(
+            "You haven't specified `bin_width` or `bin_num`. Such option is available only with categorical `mapping.col` or `mapping.row`.",
+        )
+    end
+    if isnothing(bin_width)
+        bins = range(; start = c_min, length = bin_num + 1, stop = c_max)
+    else
+        bins = range(; start = c_min, step = bin_width, stop = c_max)
+    end
+    return bins
+end
+
+function number_of_topoplots(
+    df::DataFrame;
+    bin_width = nothing,
+    bin_num = nothing,
+    bins,
+    mapping = config.mapping,
+)
+    if !isnothing(bin_width) | !isnothing(bin_num)
+        if typeof(df[:, mapping.col]) == Vector{String}
+            error(
+                "Parameters `bin_width` or `bin_num` are only allowed with continonus `mapping.col` or `mapping.row`, while you specifed categorical.",
+            )
+        end
+        cont_new = cut(df[:, mapping.col], bins; extend = true)
+        n = length(unique(cont_new))
+    else
+        n = length(unique(df[:, mapping.col]))
+    end
+    return n
+end
+
+"""
+    data_binning(df; col_y = :erp, fun = mean, grouping = [])
+Group `DataFrame` according to topoplot coordinates and apply aggregation function.
+
+Arguments:
+- `df::AbstractTable`\\
+    Requires columns `:cont_cuts`, `col_y` (default `:erp`), and all columns in `grouping` (`col_coord`, `row_coord`, `label`);
+- `col_y = :erp` \\
+    The column to combine over (with `fun`);
+- `fun = mean()`\\
+    Function to combine.
+- `grouping = []`\\
+    Vector of symbols or strings, columns to group by the data before aggregation. Values of `nothing` are ignored.
+
+**Return Value:** `DataFrame`.
+"""
+function data_binning(df; col_y = :erp, fun = mean, grouping = [])
+    df = deepcopy(df) # cut seems to change stuff inplace
+    grouping = grouping[.!isnothing.(grouping)]
+    df_grouped = groupby(df, unique([:cont_cuts, grouping...]))
+    df_combined = combine(df_grouped, col_y => fun)
+    rename!(df_combined, names(df_combined)[end] => col_y) # renames estimate_fun to estimate    
+    return df_combined
+end

--- a/test/test_toposeries1.jl
+++ b/test/test_toposeries1.jl
@@ -212,23 +212,6 @@ end
     )
 end
 
-@testset "basic eeg_topoplot_series" begin
-    df = DataFrame(
-        :erp => repeat(1:64, 100),
-        :cont_cuts => repeat(1:20, 5 * 64),
-        :label => repeat(1:64, 100),
-        :col_coord => repeat(1:5, 20 * 64),
-        :row_coord => repeat(1:1, 6400),
-    ) # simulated data
-    UnfoldMakie.eeg_topoplot_series(
-        df;
-        bin_width = 5,
-        positions = positions,
-        col = :col_coord,
-        row = :row_coord,
-    )
-end
-
 @testset "toposeries: GridSubposition" begin
     f = Figure(size = (500, 500))
     plot_topoplotseries!(
@@ -241,9 +224,6 @@ end
     )
 end
 
-@testset "eeg_array_to_dataframe" begin
-    eeg_array_to_dataframe(rand(2, 2))
-end
 
 @testset "contours" begin
     plot_topoplotseries(
@@ -321,5 +301,18 @@ end
         bin_num = 2,
         positions = positions,
         topo_attributes = (; interpolation = DelaunayMesh()),
+    )
+end
+
+@testset "eeg_array_to_dataframe" begin
+    eeg_array_to_dataframe(rand(2, 2))
+end
+
+@testset "eeg_topoplot_series" begin
+    matrix = rand(64, 5) # simulated data
+    UnfoldMakie.eeg_topoplot_series(
+        matrix;
+        layout = [(1, 1), (1, 2), (1, 3), (1, 4), (1, 5)],
+        positions = positions,
     )
 end

--- a/test/test_toposeries1.jl
+++ b/test/test_toposeries1.jl
@@ -104,7 +104,7 @@ end
     )
 end
 
-@testset "toposeries: xlabel" begin
+@testset "toposeries: xlabel as text" begin
     f = Figure()
     ax = Axis(f[1, 1])
     plot_topoplotseries!(f[1, 1], df; bin_width = 80, positions = positions)


### PR DESCRIPTION
- making the code of toposeries easier and faster (?). Now eeg_series accepts Matrix with size of n_electrodes*n_toposeries instead of DataFrame with all data and binned colums
- supportive functions are moved to toposeries_support.jl
- adding citation of JOOS paper