### PR TITLE
compat: allow Unfold v0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -56,7 +56,7 @@ SparseArrays = "1"
 StaticArrays = "1"
 Statistics = "1"
 TopoPlots = "0.1, 0.2"
-Unfold = "0.6, 0.7"
+Unfold = "0.6, 0.7, 0.8"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
the  upcoming unfold 0.8 breaking release does not have any impact on this paper. breaking is only the `MixedModels` handling, where no visualization exists as of now (why dont we have some though :-P)