### PR TITLE
fix terms in plot_splines.jl

### DIFF
--- a/src/plot_splines.jl
+++ b/src/plot_splines.jl
@@ -44,7 +44,7 @@ function plot_splines(
 
     ga = f[1, 1] = GridLayout()
 
-    terms = Unfold.formulas(m)[1].rhs.terms
+    terms = Unfold.terms(Unfold.formulas(m)[1].rhs)
     spl_title = join(terms, " + ")
 
     splFunction = Base.get_extension(Unfold, :UnfoldBSplineKitExt).splFunction


### PR DESCRIPTION
While this plot worked for non-overlap corrected models, it didnt for overlap-corrected ones. This should fix it