### PR TITLE
Fix StackOverflow for 3D input in plot_erpimage function

### DIFF
--- a/src/general_plots/plot_erpimage.jl
+++ b/src/general_plots/plot_erpimage.jl
@@ -44,6 +44,18 @@ $(_docstring(:erpimage))
 
 **Return Value:** `Figure` displaying the ERP image. 
 """
+
+# Catching 3d input + helpful error for user
+function plot_erpimage(data::AbstractArray{<:Real,3}; kwargs...)
+    error(
+        "plot_erpimage received 3D array of size $(size(data)) " *
+        "(channels, time, trials). " *
+        "Select or fix a single channel first. " *
+        "Format should follow `plot_erpimage(data[x, :, :])`, " *
+        " where x is a constant."
+    )
+end
+
 plot_erpimage(data; kwargs...) = plot_erpimage!(Figure(), data; kwargs...)
 
 plot_erpimage(

--- a/src/general_plots/plot_erpimage.jl
+++ b/src/general_plots/plot_erpimage.jl
@@ -44,15 +44,12 @@ $(_docstring(:erpimage))
 
 **Return Value:** `Figure` displaying the ERP image. 
 """
-
 # Catching 3d input + helpful error for user
 function plot_erpimage(data::AbstractArray{<:Real,3}; kwargs...)
     error(
-        "plot_erpimage received 3D array of size $(size(data)) " *
-        "likely (channels, time, trials). " *
-        "Select or fix a single channel first. " *
-        "E.g. via  `plot_erpimage(data[x, :, :])`, " *
-        " where x is a integer."
+        "plot_erpimage received 3-dimensional array of size $(size(data)).\n" *
+        "Select a single channel first.\n" *
+        "E.g. via `plot_erpimage(data[x, :, :])`, where x is an integer."
     )
 end
 

--- a/src/general_plots/plot_erpimage.jl
+++ b/src/general_plots/plot_erpimage.jl
@@ -44,7 +44,6 @@ $(_docstring(:erpimage))
 
 **Return Value:** `Figure` displaying the ERP image. 
 """
-# Catching 3d input + helpful error for user
 function plot_erpimage(data::AbstractArray{<:Real,3}; kwargs...)
     error(
         "plot_erpimage received 3-dimensional array of size $(size(data)).\n" *

--- a/src/general_plots/plot_erpimage.jl
+++ b/src/general_plots/plot_erpimage.jl
@@ -49,10 +49,10 @@ $(_docstring(:erpimage))
 function plot_erpimage(data::AbstractArray{<:Real,3}; kwargs...)
     error(
         "plot_erpimage received 3D array of size $(size(data)) " *
-        "(channels, time, trials). " *
+        "likely (channels, time, trials). " *
         "Select or fix a single channel first. " *
-        "Format should follow `plot_erpimage(data[x, :, :])`, " *
-        " where x is a constant."
+        "E.g. via  `plot_erpimage(data[x, :, :])`, " *
+        " where x is a integer."
     )
 end
 

--- a/test/test_erpimage.jl
+++ b/test/test_erpimage.jl
@@ -218,3 +218,13 @@ end
 @testset "ERP image: yticklabelsvisible" begin
     plot_erpimage(dat; axis = (; yticklabelsvisible = false))
 end
+
+@testset "ERP image with 3D input" begin
+    err1 = nothing
+    try
+        plot_erpimage(rand(15, 20, 3))
+    catch err1
+    end
+    @test err1 isa ErrorException
+    @test occursin("3D array", err1.msg)
+end

--- a/test/test_erpimage.jl
+++ b/test/test_erpimage.jl
@@ -226,5 +226,5 @@ end
     catch err1
     end
     @test err1 isa ErrorException
-    @test occursin("3D array", err1.msg)
+    @test occursin("3-dimensional array", err1.msg)
 end


### PR DESCRIPTION
#429

Problem:
- Passing 3D input to plot_erpimage function caused an infinite recursion loop, throwing StackOverflow Error

Solution:
- Added code (starting line 47) to plot_erpimage.jl to catch the 3D input and give the user a helpful error to help them correct the input format
- Added a test to the end of test_erpimage.jl file