### PR TITLE
Document montage usage in topoplots

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -27,7 +27,7 @@
     },
     {
       "login": "Link250",
-      "name": "Quantum",
+      "name": "Daniel Baumgartner",
       "avatar_url": "https://avatars.githubusercontent.com/u/4541950?v=4",
       "profile": "https://github.com/Link250",
       "contributions": [
@@ -53,7 +53,7 @@
     },
     {
       "login": "NiklasMGaertner",
-      "name": "NiklasMGaertner",
+      "name": "Niklas Gaertner",
       "avatar_url": "https://avatars.githubusercontent.com/u/54365174?v=4",
       "profile": "https://github.com/NiklasMGaertner",
       "contributions": [
@@ -63,7 +63,7 @@
     },
     {
       "login": "SorenDoring",
-      "name": "SorenDoring",
+      "name": "Soren Doring",
       "avatar_url": "https://avatars.githubusercontent.com/u/54365184?v=4",
       "profile": "https://github.com/SorenDoring",
       "contributions": [
@@ -73,7 +73,7 @@
     },
     {
       "login": "lokmanfl",
-      "name": "lokmanfl",
+      "name": "Fadil Furkan Lokman",
       "avatar_url": "https://avatars.githubusercontent.com/u/44772645?v=4",
       "profile": "https://github.com/lokmanfl",
       "contributions": [
@@ -99,6 +99,18 @@
       "profile": "https://reneskukies.de/",
       "contributions": [
         "doc"
+      ]
+    },
+    {
+      "login": "kbelgal02",
+      "name": "Kiran Belgal",
+      "avatar_url": "https://avatars.githubusercontent.com/u/253596950?v=4",
+      "profile": "https://github.com/kbelgal02",
+      "contributions": [
+        "bug",
+        "code",
+        "maintenance",
+        "test",
       ]
     }
   ],

--- a/docs/literate/how_to/complex_figures.jl
+++ b/docs/literate/how_to/complex_figures.jl
@@ -316,12 +316,8 @@ function complex_figure4(
 )
     f = Figure(size = (1800, 1000))
     panel_background = colorant"#F4F3EF"
-    axis_fontsizes = (;
-        xlabelsize = 24,
-        ylabelsize = 24,
-        xticklabelsize = 18,
-        yticklabelsize = 18,
-    )
+    axis_fontsizes =
+        (; xlabelsize = 24, ylabelsize = 24, xticklabelsize = 18, yticklabelsize = 18)
     colorbar_style = (; labelsize = 24, ticklabelsize = 18)
 
     top_row = f[1, 1] = GridLayout()

--- a/docs/literate/how_to/complex_figures.jl
+++ b/docs/literate/how_to/complex_figures.jl
@@ -222,11 +222,14 @@ function complex_figure3(
         density_axis = (; backgroundcolor = colorant"#F4F3EF"),
     )
 
-    topo_df.coefname .= "B" # create a second category
-    topo_df.estimate .+= rand(length(topo_df.estimate)) * 0.1
+    parallel_df = subset(topo_df, :channel => x -> x .< 8, :time => x -> x .< 0)
+    parallel_df_b = copy(parallel_df)
+    parallel_df_b.coefname .= "B"
+    parallel_df_b.estimate .+= 0.1
+    parallel_df = vcat(parallel_df, parallel_df_b)
     plot_parallelcoordinates(
         gh,
-        subset(topo_df, :channel => x -> x .< 8, :time => x -> x .< 0);
+        parallel_df;
         mapping = (; color = :coefname),
         normalize = :minmax,
         ax_labels = ["FP1", "F3", "F7", "FC3", "C3", "C5", "P3", "P7"],
@@ -312,8 +315,13 @@ function complex_figure4(
 )
     f = Figure(size = (1800, 1000))
 
-    (ga, gb, gc, gd) = (f[1, 1], f[1, 2], f[1, 3], f[1, 4])
-    (ge, gf, gg, gh) = (f[2, 1], f[2, 2], f[2, 3], f[2, 4])
+    top_row = f[1, 1] = GridLayout()
+    bottom_row = f[2, 1] = GridLayout()
+
+    (ga, gb, gc, gd) =
+        (top_row[1, 1], top_row[1, 2], top_row[1, 3], top_row[1, 4])
+    (ge, gf, gh) = (bottom_row[1, 1], bottom_row[1, 2], bottom_row[1, 4])
+    gg = bottom_row[1, 3] = GridLayout()
 
     plot_erp!(
         ga,
@@ -338,7 +346,12 @@ function complex_figure4(
         gb,
         topo_df;
         positions = positions,
-        topo_axis = (; height = Relative(0.4), width = Relative(0.4)),
+        topo_axis = (;
+            height = Relative(0.4),
+            width = Relative(0.4),
+            tellwidth = false,
+            tellheight = false,
+        ),
         axis = (; backgroundcolor = colorant"#F4F3EF",
             xlabel = "Time [ms]", xlabelsize = 24, ylabelsize = 24, xticklabelsize = 18,
             yticklabelsize = 18),
@@ -414,12 +427,28 @@ function complex_figure4(
         positions = positions,
         center_label = "Time [ms]",
         predictor = :time,
+        plot_radius = 0.9,
         topo_attributes = (; label_scatter = false, contours = false),
-        topo_axis = (; backgroundcolor = colorant"#F4F3EF"),
+        topo_axis = (;
+            backgroundcolor = colorant"#F4F3EF",
+            width = Relative(0.3),
+            height = Relative(0.3),
+        ),
         axis = (; backgroundcolor = colorant"#F4F3EF", xlabelsize = 24, ylabelsize = 24),
         predictor_bounds = [80, 320],
-        colorbar = (; height = 180, labelsize = 24, ticklabelsize = 18),
+        colorbar = (;
+            position = :bottom,
+            vertical = false,
+            valign = :bottom,
+            labelsize = 24,
+            ticklabelsize = 18,
+        ),
     )
+    colsize!(gg, 1, Relative(1))
+    rowsize!(gg, 1, Relative(0.88))
+    rowsize!(gg, 2, Relative(0.12))
+    rowgap!(gg, 5)
+
     plot_channelimage!(
         gh,
         topo_array[1:30, :, 1],
@@ -435,18 +464,22 @@ function complex_figure4(
         colorbar = (; height = 180, labelsize = 24, ticklabelsize = 18),
     )
 
+    for row_layout in (top_row, bottom_row), column in 1:4
+        colsize!(row_layout, column, Relative(1 / 4))
+    end
+
     for (label, layout) in
         zip(
         ["A", "B", "C", "D", "E", "F", "G", "H"],
         [ga, gb, gc, gd, ge, gf, gg, gh],
     )
         Label(
-            layout[1, 1, TopLeft()],
+            layout[1, 1, Top()],
             label,
             fontsize = 26,
             font = :bold,
             padding = (20, 20, 22, 0),
-            halign = :right,
+            halign = :left,
         )
     end
     f
@@ -468,6 +501,5 @@ f = with_theme(Theme(; backgroundcolor = colorant"#F4F3EF")) do
         times,
     )
 end
-
 
 #save("complex_figure4.png", f)

--- a/docs/literate/how_to/complex_figures.jl
+++ b/docs/literate/how_to/complex_figures.jl
@@ -383,12 +383,7 @@ function complex_figure4(
             xlabelsize = 24,
             ylabelsize = 24,
         ),
-        colorbar = (;
-            colorbar_style...,
-            position = :bottom,
-            vertical = false,
-            width = 240,
-        ),
+        colorbar = (; colorbar_style..., position = :bottom, vertical = false, width = 240),
         visual = (; contours = false),
     )
     translate!(panel_e_objects.colorbar.blockscene, 0, -30, 100)

--- a/docs/literate/how_to/complex_figures.jl
+++ b/docs/literate/how_to/complex_figures.jl
@@ -1,4 +1,3 @@
-using Unfold: coefnames
 # # Complex figures
 
 #=
@@ -10,7 +9,7 @@ This section discusses how users can incorporate multiple plots into a single fi
 
 using UnfoldMakie;
 using CairoMakie
-using DataFramesMeta
+using DataFrames
 using UnfoldSim
 using Unfold
 using MakieThemes
@@ -23,30 +22,28 @@ using TopoPlots;
 # ```
 topo_df, positions = UnfoldMakie.example_data("TopoPlots.jl")
 topo_array, _ = TopoPlots.example_data()
-toposeries_df =
+toposeries_data =
     UnfoldMakie.eeg_array_to_dataframe(topo_array[:, :, 1], string.(1:length(positions)));
-labels_30 = UnfoldMakie.example_montage("labels_30");
+biosemi32 = get_montage("biosemi32");
 
-uf_deconv = UnfoldMakie.example_data("UnfoldLinearModelContinuousTime")
-uf = UnfoldMakie.example_data("UnfoldLinearModel");
-results = coeftable(uf)
-uf_5chan = UnfoldMakie.example_data("UnfoldLinearModelMultiChannel");
+continuous_time_model = UnfoldMakie.example_data("UnfoldLinearModelContinuousTime")
+linear_model = UnfoldMakie.example_data("UnfoldLinearModel");
+multichannel_model = UnfoldMakie.example_data("UnfoldLinearModelMultiChannel");
 
-dat_e, evts, times = UnfoldMakie.example_data("sort_data")
-d_singletrial, _ = UnfoldSim.predef_eeg(; return_epoched = true);
+erpimage_data, events, time_points = UnfoldMakie.example_data("sort_data")
+epoched_data, _ = UnfoldSim.predef_eeg(; return_epoched = true);
 
-m = UnfoldMakie.example_data("UnfoldLinearModel");
-results = coeftable(m);
-results.coefname =
-    replace(results.coefname, "condition: face" => "face", "(Intercept)" => "car");
-results = filter(row -> row.coefname != "continuous", results);
+coefficient_table = coeftable(linear_model);
+coefficient_table.coefname =
+    replace(coefficient_table.coefname, "condition: face" => "face", "(Intercept)" => "car");
+coefficient_table = filter(row -> row.coefname != "continuous", coefficient_table);
 
-df_circ = DataFrame(
+circular_topo_data = DataFrame(
     :estimate => eachcol(Float64.(topo_array[:, 100:40:300, 1])),
     :circular_variable => [0, 50, 80, 120, 180, 210],
     :time => 100:40:300,
 );
-df_circ = flatten(df_circ, :estimate);
+circular_topo_data = flatten(circular_topo_data, :estimate);
 # ```@raw html
 # </details >
 # ```
@@ -64,12 +61,12 @@ f = Figure(size = (750, 500))
 with_theme(theme_ggthemr(:fresh)) do
     plot_erp!(
         f[1, 1],
-        coeftable(uf_deconv);
+        coeftable(continuous_time_model);
         mapping = (; color = :coefname => "Conditions"),
     )
     plot_erp!(
         f[1, 2],
-        effects(Dict(:condition => ["car", "face"]), uf_deconv),
+        effects(Dict(:condition => ["car", "face"]), continuous_time_model),
         mapping = (; y = :yhat, color = :condition => "Conditions"),
     )
     plot_butterfly!(f[2, 1:2], topo_df; positions = positions,
@@ -99,9 +96,9 @@ begin
         to = [0.2, 0.5], # if coefname not specified, line should be black
         coefname = ["(Intercept)", "category: face"],
     )
-    plot_erp!(f[2, 1:2], results, significance = pvals, stderror = true)
+    plot_erp!(f[2, 1:2], coefficient_table, significance = pvals, stderror = true)
 
-    plot_designmatrix!(f[2, 3], designmatrix(uf))
+    plot_designmatrix!(f[2, 3], designmatrix(linear_model))
 
     plot_topoplot!(f[3, 1], topo_array[:, 150, 1]; positions = positions)
     plot_topoplotseries!(
@@ -112,7 +109,7 @@ begin
         mapping = (; label = :channel),
     )
 
-    res_effects = effects(Dict(:continuous => -5:0.5:5), uf_deconv)
+    res_effects = effects(Dict(:continuous => -5:0.5:5), continuous_time_model)
 
     plot_erp!(
         f[2, 4:5],
@@ -121,9 +118,13 @@ begin
         legend = (; nbanks = 2),
     )
 
-    plot_parallelcoordinates(f[3, 2:3], uf_5chan; mapping = (; color = :coefname))
+    plot_parallelcoordinates(
+        f[3, 2:3],
+        multichannel_model;
+        mapping = (; color = :coefname),
+    )
 
-    plot_erpimage!(f[1, 4:5], times, d_singletrial)
+    plot_erpimage!(f[1, 4:5], time_points, epoched_data)
     plot_circular_topoplots!(
         f[3:4, 4:5],
         topo_df[in.(topo_df.time, Ref(-0.3:0.1:0.5)), :];
@@ -147,29 +148,31 @@ function complex_figure3(
     topo_df,
     topo_array,
     positions,
-    toposeries_df,
-    labels_30,
-    results,
-    df_circ,
-    dat_e,
-    evts,
-    times,
+    toposeries_data,
+    biosemi32,
+    coefficient_table,
+    circular_topo_data,
+    erpimage_data,
+    events,
+    time_points,
 )
     f = Figure(size = (1200, 1700))
-    (ga, gc, ge, gg, gi) = (f[1, 1], f[2, 1], f[3, 1], f[4, 1], f[5:6, 1])
-    (gb, gd, gf, gh, gj) = (f[1, 2], f[2, 2], f[3, 2], f[4, 2], f[5:6, 2])
+    (panel_a, panel_c, panel_e, panel_g, panel_i) =
+        (f[1, 1], f[2, 1], f[3, 1], f[4, 1], f[5:6, 1])
+    (panel_b, panel_d, panel_f, panel_h, panel_j) =
+        (f[1, 2], f[2, 2], f[3, 2], f[4, 2], f[5:6, 2])
 
     plot_erp!(
-        ga,
-        results;
-        :stderror => true,
+        panel_a,
+        coefficient_table;
+        stderror = true,
         mapping = (; color = :coefname => "Conditions"),
         axis = (; backgroundcolor = colorant"#F4F3EF", xlabel = "Time [ms]"),
     )
     hlines!(0, color = :gray, linewidth = 1)
     vlines!(0, color = :gray, linewidth = 1)
     plot_butterfly!(
-        gb,
+        panel_b,
         topo_df;
         positions = positions,
         topo_axis = (; height = Relative(0.4), width = Relative(0.4)),
@@ -178,7 +181,7 @@ function complex_figure3(
     hlines!(0, color = :gray, linewidth = 1)
     vlines!(0, color = :gray, linewidth = 1)
     plot_topoplot!(
-        gc,
+        panel_c,
         topo_array[:, 340, 1];
         positions = positions,
         topo_axis = (; backgroundcolor = colorant"#F4F3EF"),
@@ -186,8 +189,8 @@ function complex_figure3(
     )
 
     plot_topoplotseries!(
-        gd,
-        toposeries_df;
+        panel_d,
+        toposeries_data;
         bin_width = 80,
         positions = positions,
         visual = (label_scatter = false, contours = false),
@@ -197,7 +200,7 @@ function complex_figure3(
     )
 
     plot_erpgrid!(
-        ge,
+        panel_e,
         topo_array[:, :, 1],
         positions;
         indicator_grid_axis = (;
@@ -208,16 +211,16 @@ function complex_figure3(
     )
 
     plot_erpimage!(
-        gf,
-        times,
-        dat_e;
-        sortvalues = evts.Δlatency,
+        panel_f,
+        time_points,
+        erpimage_data;
+        sortvalues = events.Δlatency,
         axis = (; xlabel = "Time [ms]"),
     )
-    m1 = UnfoldMakie.example_data("UnfoldLinearModelwith1Spline")
+    spline_model = UnfoldMakie.example_data("UnfoldLinearModelwith1Spline")
     plot_splines!(
-        gg,
-        m1;
+        panel_g,
+        spline_model;
         spline_axis = (; backgroundcolor = colorant"#F4F3EF"),
         density_axis = (; backgroundcolor = colorant"#F4F3EF"),
     )
@@ -228,7 +231,7 @@ function complex_figure3(
     parallel_df_b.estimate .+= 0.1
     parallel_df = vcat(parallel_df, parallel_df_b)
     plot_parallelcoordinates(
-        gh,
+        panel_h,
         parallel_df;
         mapping = (; color = :coefname),
         normalize = :minmax,
@@ -237,8 +240,8 @@ function complex_figure3(
     )
 
     plot_circular_topoplots!(
-        gi,
-        df_circ;
+        panel_i,
+        circular_topo_data;
         positions = positions,
         center_label = "Time [s]",
         predictor = :time,
@@ -249,17 +252,18 @@ function complex_figure3(
         colorbar = (; height = 180),
     )
     plot_channelimage!(
-        gj,
-        topo_array[1:30, :, 1],
-        positions[1:30],
-        labels_30;
+        panel_j,
+        topo_array[1:32, :, 1],
+        biosemi32.positions,
+        biosemi32.labels;
         axis = (; xlabel = "Time [ms]"),
     )
 
     for (label, layout) in
         zip(
         ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"],
-        [ga, gb, gc, gd, ge, gf, gg, gh, gi, gj],
+        [panel_a, panel_b, panel_c, panel_d, panel_e, 
+        panel_f, panel_g, panel_h, panel_i, panel_j],
     )
         Label(
             layout[1, 1, TopLeft()],
@@ -280,13 +284,13 @@ with_theme(Theme(; backgroundcolor = colorant"#F4F3EF")) do
         topo_df,
         topo_array,
         positions,
-        toposeries_df,
-        labels_30,
-        results,
-        df_circ,
-        dat_e,
-        evts,
-        times,
+        toposeries_data,
+        biosemi32,
+        coefficient_table,
+        circular_topo_data,
+        erpimage_data,
+        events,
+        time_points,
     )
 end
 
@@ -296,36 +300,40 @@ end
 # <details>
 # <summary>Click to expand</summary>
 # ```
-results = coeftable(m)
-results.coefname =
-    replace(results.coefname, "condition: face" => "face", "(Intercept)" => "car")
-results = filter(row -> row.coefname != "continuous", results)
-
 function complex_figure4(
     topo_df,
     topo_array,
     positions,
-    toposeries_df,
-    labels_30,
-    results,
-    df_circ,
-    dat_e,
-    evts,
-    times,
+    toposeries_data,
+    biosemi32,
+    coefficient_table,
+    circular_topo_data,
+    erpimage_data,
+    events,
+    time_points,
 )
     f = Figure(size = (1800, 1000))
+    panel_background = colorant"#F4F3EF"
+    axis_fontsizes = (;
+        xlabelsize = 24,
+        ylabelsize = 24,
+        xticklabelsize = 18,
+        yticklabelsize = 18,
+    )
+    colorbar_style = (; labelsize = 24, ticklabelsize = 18)
 
     top_row = f[1, 1] = GridLayout()
     bottom_row = f[2, 1] = GridLayout()
 
-    (ga, gb, gc, gd) =
+    (panel_a, panel_b, panel_c, panel_d) =
         (top_row[1, 1], top_row[1, 2], top_row[1, 3], top_row[1, 4])
-    (ge, gf, gh) = (bottom_row[1, 1], bottom_row[1, 2], bottom_row[1, 4])
-    gg = bottom_row[1, 3] = GridLayout()
+    (panel_e, panel_f, panel_h) =
+        (bottom_row[1, 1], bottom_row[1, 2], bottom_row[1, 4])
+    panel_g = bottom_row[1, 3] = GridLayout()
 
     plot_erp!(
-        ga,
-        results;
+        panel_a,
+        coefficient_table;
         :stderror => true,
         mapping = (; color = :coefname => "Conditions:"),
         legend = (;
@@ -336,14 +344,18 @@ function complex_figure4(
             titlesize = 20,
             nbanks = 2,
         ),
-        axis = (; backgroundcolor = colorant"#F4F3EF", xlabel = "Time [ms]", width = 350,
-            xlabelsize = 24, ylabelsize = 24, xticklabelsize = 18, yticklabelsize = 18),
+        axis = (;
+            axis_fontsizes...,
+            backgroundcolor = panel_background,
+            xlabel = "Time [ms]",
+            width = 350,
+        ),
     )
     hlines!(0, color = :gray, linewidth = 1)
     vlines!(0, color = :gray, linewidth = 1)
 
     plot_butterfly!(
-        gb,
+        panel_b,
         topo_df;
         positions = positions,
         topo_axis = (;
@@ -352,49 +364,54 @@ function complex_figure4(
             tellwidth = false,
             tellheight = false,
         ),
-        axis = (; backgroundcolor = colorant"#F4F3EF",
-            xlabel = "Time [ms]", xlabelsize = 24, ylabelsize = 24, xticklabelsize = 18,
-            yticklabelsize = 18),
+        axis = (; axis_fontsizes..., backgroundcolor = panel_background, xlabel = "Time [ms]"),
     )
     hlines!(0, color = :gray, linewidth = 1)
     vlines!(0, color = :gray, linewidth = 1)
 
-    plot_topoplot!(
-        ge,
+    panel_e_objects = plot_topoplot!(
+        panel_e,
         topo_array[:, 340, 1];
         positions = positions,
-        topo_axis = (; backgroundcolor = colorant"#F4F3EF"),
+        return_objects = true,
+        topo_axis = (; backgroundcolor = panel_background),
         axis = (;
             xlabel = "[340 ms]",
-            backgroundcolor = colorant"#F4F3EF",
+            backgroundcolor = panel_background,
             xlabelsize = 24,
             ylabelsize = 24,
         ),
-        colorbar = (; position = :bottom, vertical = false, width = 180, labelsize = 24, ticklabelsize = 18),
+        colorbar = (;
+            colorbar_style...,
+            position = :bottom,
+            vertical = false,
+            width = 240,
+        ),
         visual = (; contours = false),
     )
+    translate!(panel_e_objects.colorbar.blockscene, 0, -30, 100)
 
     plot_topoplotseries!(
-        gf,
-        toposeries_df;
-        bin_width = 80,
-        nrows = 3,
+        panel_f,
+        toposeries_data;
+        bin_num = 4,
+        nrows = 2,
         positions = positions,
         visual = (label_scatter = false, contours = false),
         layout = (; use_colorbar = true),
-        topo_axis = (; backgroundcolor = colorant"#F4F3EF", xlabelsize = 18),
+        topo_axis = (; backgroundcolor = panel_background, xlabelsize = 18),
         axis = (;
-            xlabelpadding = 70,
-            backgroundcolor = colorant"#F4F3EF",
+            xlabelpadding = 50,
+            backgroundcolor = panel_background,
             xlabel = "        Time [ms]",
             xlabelsize = 24,
             ylabelsize = 24,
         ),
-        colorbar = (; height = 180, labelsize = 24, ticklabelsize = 18),
+        colorbar = (; colorbar_style..., height = 180),
     )
 
     plot_erpgrid!(
-        gc,
+        panel_c,
         topo_array[:, :, 1],
         positions;
         indicator_grid_axis = (;
@@ -402,66 +419,61 @@ function complex_figure4(
             text_x_kwargs = (; text = "s", fontsize = 24),
             text_y_kwargs = (; text = "µV", fontsize = 24),
         ),
-        axis = (; backgroundcolor = colorant"#F4F3EF",),
-        colorbar = (; height = 180, labelsize = 24, ticklabelsize = 18),
+        axis = (; backgroundcolor = panel_background),
+        colorbar = (; colorbar_style..., height = 180),
     )
 
     plot_erpimage!(
-        gd,
-        times,
-        dat_e;
-        sortvalues = evts.Δlatency,
+        panel_d,
+        time_points,
+        erpimage_data;
+        sortvalues = events.Δlatency,
         axis = (;
+            axis_fontsizes...,
             xlabel = "Time [ms]",
-            xlabelsize = 24,
-            ylabelsize = 24,
-            xticklabelsize = 18,
-            yticklabelsize = 18,
         ),
-        colorbar = (; height = 180, labelsize = 24, ticklabelsize = 18),
+        colorbar = (; colorbar_style..., height = 180),
     )
 
-    plot_circular_topoplots!(
-        gg,
-        df_circ;
+    panel_g_objects = plot_circular_topoplots!(
+        panel_g,
+        circular_topo_data;
         positions = positions,
+        return_objects = true,
         center_label = "Time [ms]",
         predictor = :time,
         plot_radius = 0.9,
         topo_attributes = (; label_scatter = false, contours = false),
         topo_axis = (;
-            backgroundcolor = colorant"#F4F3EF",
+            backgroundcolor = panel_background,
             width = Relative(0.3),
             height = Relative(0.3),
         ),
-        axis = (; backgroundcolor = colorant"#F4F3EF", xlabelsize = 24, ylabelsize = 24),
+        axis = (; backgroundcolor = panel_background, xlabelsize = 24, ylabelsize = 24),
         predictor_bounds = [80, 320],
         colorbar = (;
             position = :bottom,
             vertical = false,
             valign = :bottom,
-            labelsize = 24,
-            ticklabelsize = 18,
+            colorbar_style...,
+            width = 240,
         ),
     )
-    colsize!(gg, 1, Relative(1))
-    rowsize!(gg, 1, Relative(0.88))
-    rowsize!(gg, 2, Relative(0.12))
-    rowgap!(gg, 5)
+    translate!(panel_g_objects.colorbar.blockscene, 0, -30, 100)
+    colsize!(panel_g, 1, Relative(1))
+    rowsize!(panel_g, 1, Relative(0.99))
+    rowgap!(panel_g, 5)
 
     plot_channelimage!(
-        gh,
-        topo_array[1:30, :, 1],
-        positions[1:30],
-        labels_30;
+        panel_h,
+        topo_array[1:32, :, 1],
+        biosemi32.positions,
+        biosemi32.labels;
         axis = (;
+            axis_fontsizes...,
             xlabel = "Time [ms]",
-            xlabelsize = 24,
-            ylabelsize = 24,
-            xticklabelsize = 18,
-            yticklabelsize = 18,
         ),
-        colorbar = (; height = 180, labelsize = 24, ticklabelsize = 18),
+        colorbar = (; colorbar_style..., height = 180),
     )
 
     for row_layout in (top_row, bottom_row), column in 1:4
@@ -471,7 +483,7 @@ function complex_figure4(
     for (label, layout) in
         zip(
         ["A", "B", "C", "D", "E", "F", "G", "H"],
-        [ga, gb, gc, gd, ge, gf, gg, gh],
+        [panel_a, panel_b, panel_c, panel_d, panel_e, panel_f, panel_g, panel_h],
     )
         Label(
             layout[1, 1, Top()],
@@ -492,13 +504,13 @@ f = with_theme(Theme(; backgroundcolor = colorant"#F4F3EF")) do
         topo_df,
         topo_array,
         positions,
-        toposeries_df,
-        labels_30,
-        results,
-        df_circ,
-        dat_e,
-        evts,
-        times,
+        toposeries_data,
+        biosemi32,
+        coefficient_table,
+        circular_topo_data,
+        erpimage_data,
+        events,
+        time_points,
     )
 end
 

--- a/docs/literate/how_to/complex_figures.jl
+++ b/docs/literate/how_to/complex_figures.jl
@@ -478,7 +478,7 @@ function complex_figure4(
         colorbar = (; colorbar_style..., height = 180),
     )
 
-    for row_layout in (top_row, bottom_row), column in 1:4
+    for row_layout in (top_row, bottom_row), column = 1:4
         colsize!(row_layout, column, Relative(1 / 4))
     end
 

--- a/docs/literate/how_to/complex_figures.jl
+++ b/docs/literate/how_to/complex_figures.jl
@@ -25,6 +25,8 @@ topo_array, _ = TopoPlots.example_data()
 toposeries_data =
     UnfoldMakie.eeg_array_to_dataframe(topo_array[:, :, 1], string.(1:length(positions)));
 biosemi32 = get_montage("biosemi32");
+# Exclude the three fiducial landmarks: Nz, LPA, and RPA.
+biosemi32 = (; labels = biosemi32.labels[1:32], positions = biosemi32.positions[1:32]);
 
 continuous_time_model = UnfoldMakie.example_data("UnfoldLinearModelContinuousTime")
 linear_model = UnfoldMakie.example_data("UnfoldLinearModel");

--- a/docs/literate/how_to/complex_figures.jl
+++ b/docs/literate/how_to/complex_figures.jl
@@ -482,8 +482,7 @@ function complex_figure4(
         colsize!(row_layout, column, Relative(1 / 4))
     end
 
-    for (label, layout) in
-        zip(
+    for (label, layout) in zip(
         ["A", "B", "C", "D", "E", "F", "G", "H"],
         [panel_a, panel_b, panel_c, panel_d, panel_e, panel_f, panel_g, panel_h],
     )

--- a/docs/literate/how_to/montage.jl
+++ b/docs/literate/how_to/montage.jl
@@ -105,7 +105,7 @@ plot_topoplot(
     positions = montage.positions,
     labels = montage.labels,
     axis = (; title = "BioSemi 16", xlabel = "Time window"),
-    visual = (; label_text = true),
+    visual = (; label_text =  true),
 )
 
 # ## Use a subset of standard positions
@@ -150,3 +150,28 @@ plot_topoplot(
     axis = (; title = "Custom montage"),
     visual = (; label_text = true),
 )
+
+# ## Use a montage in a topoplot series
+
+montage = get_montage("biosemi128")
+montage_data = [
+    x * cos(2π * time / 100) for x in first.(montage.positions), time in 1:100
+]
+montage_df = eeg_array_to_dataframe(montage_data, montage.labels)
+
+# Plot one time point to verify the BioSemi 128 electrode and label positions.
+plot_topoplotseries(
+    montage_df;
+    bin_num = 4, nrows = 2,
+    positions = montage.positions,
+    labels = montage.labels,
+    axis = (; xlabel = "Time windows [s]"),
+    visual = (; label_text = (; align = (:center, :center))),
+)
+
+#md # !!! note
+#md #     For larger montages, center-align the channel labels to place each
+#md #     label directly on its electrode position. This will help to avoids 
+#md #     a systematic lower-left offset. Use
+#md #     `visual = (; label_text = (; align = (:center, :center)))`.
+

--- a/docs/literate/how_to/montage.jl
+++ b/docs/literate/how_to/montage.jl
@@ -157,7 +157,7 @@ montage = get_montage("biosemi128")
 montage_data = [
     x * cos(2π * time / 100) for x in first.(montage.positions), time in 1:100
 ]
-montage_df = eeg_array_to_dataframe(montage_data, montage.labels)
+montage_df = eeg_array_to_dataframe(montage_data, montage.labels);
 
 # Plot one time point to verify the BioSemi 128 electrode and label positions.
 plot_topoplotseries(

--- a/docs/literate/how_to/montage.jl
+++ b/docs/literate/how_to/montage.jl
@@ -105,7 +105,7 @@ plot_topoplot(
     positions = montage.positions,
     labels = montage.labels,
     axis = (; title = "BioSemi 16", xlabel = "Time window"),
-    visual = (; label_text =  true),
+    visual = (; label_text = true),
 )
 
 # ## Use a subset of standard positions

--- a/docs/literate/how_to/uncertain_topo.jl
+++ b/docs/literate/how_to/uncertain_topo.jl
@@ -1,4 +1,4 @@
-# # Visualize uncertainty in topoplots
+# # [Visualize uncertainty in topoplots](@id uncertain_topoplots)
 
 # ```@raw html
 # <details>

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -29,6 +29,7 @@ makedocs(;
         canonical = "https://unfoldtoolbox.github.io/UnfoldMakie.jl",
         assets = String[],
         sidebar_sitename = false,
+        size_threshold = 20_000_000,
         example_size_threshold = 0,
     ),
     pages = [

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -29,6 +29,7 @@ makedocs(;
         canonical = "https://unfoldtoolbox.github.io/UnfoldMakie.jl",
         assets = String[],
         sidebar_sitename = false,
+        example_size_threshold = 0,
     ),
     pages = [
         "Home" => "index.md",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -62,7 +62,7 @@ plot_topoplotseries(
 
 ### 3. Advanced topics
 📌 Goal: Learn about advanced customization
-🔗 [Visualize uncertainty in topoplot series](@ref)
+🔗 [Visualize uncertainty in topoplots](generated/how_to/uncertain_topo.md)
 
 
 ## Statement of need

--- a/src/configs/docstring_template.jl
+++ b/src/configs/docstring_template.jl
@@ -31,7 +31,7 @@ function _docstring(cfg_symb::Symbol)
     )
     cbarstring =
         (cfg_symb == :erp || cfg_symb == :butterfly) ?
-        "[`AlgebraOfGraphics.colorbar!`](@ref)" :
+        "[`AlgebraOfGraphics.colorbar!`](https://aog.makie.org/stable/api#AlgebraOfGraphics.colorbar!)" :
         "[`Makie.Colorbar`](https://docs.makie.org/stable/reference/blocks/colorbar/)"
     link = Dict(
         :figure => "use `kwargs...` of [`Makie.Figure`](https://docs.makie.org/stable/explanations/figure/)",

--- a/src/general_plots/plot_circular_topoplots.jl
+++ b/src/general_plots/plot_circular_topoplots.jl
@@ -1,46 +1,45 @@
 """
     plot_circular_topoplots!(f, data::DataFrame; kwargs...)
-using ColorSchemes: topo
-using ColorSchemes: topo
-using ColorSchemes: topo
     plot_circular_topoplots(data::DataFrame; kwargs...)
 
-Plot a circular EEG topoplot.
+Plot a circular series of EEG topoplots.
+
 ## Arguments
 
 - `f::Union{GridPosition, GridLayout, Figure}`\\
-    `Figure`, `GridLayout`, or `GridPosition` to draw the plot.\\
+    Layout container in which to draw the plot.
 - `data::DataFrame`\\
-    DataFrame with data keys (columns `:y, :yhat, :estimate`), and :position (columns `:pos, :position, :positions`).
+    Data containing an amplitude column (`:y`, `:yhat`, or `:estimate`) and
+    values for the circular predictor.
 
 ## Keyword arguments (kwargs)
-- `predictor::Vector{Any} = :predictor`\\
-    The circular predictor value, defines position of topoplot across the circle.
-    Mapped around `predictor_bounds`.
-- `predictor_bounds::Vector{Int64} = [0, 360]`\\
-    The bounds of the predictor. Relevant for the axis labels.
+- `predictor::Symbol = :predictor`\\
+    Column containing the predictor values that determine the positions of the
+    topoplots around the circle.
+- `predictor_bounds::AbstractVector = [0, 360]`\\
+    Lower and upper bounds used to map predictor values onto the circular axis.
 - `positions::Vector{Point{2, Float32}} = nothing`\\
-    Positions of the [`plot_topoplot`](@ref topo_vis).
+    Two-dimensional electrode positions used by [`plot_topoplot`](@ref topo_vis).
 - `center_label::String = ""`\\
-    The text in the center of the cricle.
-- `plot_radius::String = 0.8`\\
-    The radius of the circular topoplot series plot calucalted by formula: `radius = (minwidth * plot_radius) / 2`.
+    Text displayed at the centre of the circular axis.
+- `plot_radius::Real = 0.8`\\
+    Relative radius of the circular arrangement, calculated as
+    `(minimum_layout_dimension * plot_radius) / 2`.
 - `labels::Vector{String} = nothing`\\
-    Labels for the [`plot_topoplots`](@ref topo_vis).
+    Electrode labels used to obtain positions when `positions` is not supplied.
 - `topo_axis::NamedTuple = (;)`\\
-    Here you can flexibly change configurations of the topoplot axis.\\
-    To see all options just type `?Axis` in REPL.\\
+    Attributes passed to each topoplot axis. See `?Axis` for available options.\\
     Defaults: $(supportive_defaults(:topo_default_single_circular))
 - `topo_attributes::NamedTuple = (;)`\\
-    Here you can flexibly change configurations of the topoplot interoplation.\\
-    To see all options just type `?Topoplot.topoplot` in REPL.\\
+    Attributes controlling topoplot interpolation and appearance.\\
     Defaults: $(replace(string(supportive_defaults(:topo_default_attributes; docstring = true)), "_" => "\\_"))
-- `colorbar.position = :right`\\
-     Possible options: `:right`, `:left`. Sets position of the colorbar.\\
+- `colorbar::NamedTuple = (;)`\\
+    Colorbar attributes. Set `position` to `:right`, `:left`, `:top`, or
+    `:bottom`. Colorbars at the top or bottom are horizontal automatically.
 
 $(_docstring(:circtopos))
 
-**Return Value:** `Figure` displaying the Circular topoplot series.
+**Return Value:** `Figure`.
 
 """
 plot_circular_topoplots(data::DataFrame; kwargs...) =
@@ -99,12 +98,24 @@ function plot_circular_topoplots!(
     config_kwargs!(config, colorbar = (; ticks = (cb_ticks, rounded_cb_ticks)))
 
     position = get(config.colorbar, :position, :right)
-    if !(position in (:right, :left))
-        error("colorbar.position must be :right or :left for plot_circular_topoplots")
+    if !(position in (:right, :left, :top, :bottom))
+        error(
+            "colorbar.position must be :right, :left, :top, or :bottom for plot_circular_topoplots",
+        )
     end
-    position = get(config.colorbar, :position, :right)
+    if position in (:top, :bottom)
+        config_kwargs!(config, colorbar = (; vertical = false, labelrotation = 2π))
+    end
 
-    cb_pos = position == :left ? f[1, 0] : f[1, 2]
+    cb_pos = if position == :left
+        f[1, 0]
+    elseif position == :right
+        f[1, 2]
+    elseif position == :top
+        f[0, 1]
+    else
+        f[2, 1]
+    end
     cb_kwargs = (; (k => v for (k, v) in pairs(config.colorbar) if k != :position)...)
     Colorbar(cb_pos; colorrange = (lo, hi), cb_kwargs...)
     topo_axis =

--- a/src/general_plots/plot_circular_topoplots.jl
+++ b/src/general_plots/plot_circular_topoplots.jl
@@ -36,6 +36,9 @@ Plot a circular series of EEG topoplots.
 - `colorbar::NamedTuple = (;)`\\
     Colorbar attributes. Set `position` to `:right`, `:left`, `:top`, or
     `:bottom`. Colorbars at the top or bottom are horizontal automatically.
+- `return_objects::Bool = false`\\
+    Return a named tuple containing the created axis and colorbar.\\
+    Helpful for colorbar tweaking. If `false`, returns the figure.
 
 $(_docstring(:circtopos))
 
@@ -57,6 +60,7 @@ function plot_circular_topoplots!(
     plot_radius = 0.8,
     topo_attributes = (;),
     topo_axis = (;),
+    return_objects = false,
     kwargs...,
 )
     config = PlotConfig(:circtopos)
@@ -117,7 +121,7 @@ function plot_circular_topoplots!(
         f[2, 1]
     end
     cb_kwargs = (; (k => v for (k, v) in pairs(config.colorbar) if k != :position)...)
-    Colorbar(cb_pos; colorrange = (lo, hi), cb_kwargs...)
+    cb = Colorbar(cb_pos; colorrange = (lo, hi), cb_kwargs...)
     topo_axis =
         update_axis(supportive_defaults(:topo_default_single_circular); topo_axis...)
     topo_attributes =
@@ -136,7 +140,7 @@ function plot_circular_topoplots!(
         topo_attributes,
         topo_axis,
     )
-    return f
+    return return_objects ? (; figure = f, axis = ax, colorbar = cb) : f
 end
 
 function plot_circular_axis!(ax, predictor_bounds, center_label)

--- a/src/general_plots/plot_erpgrid.jl
+++ b/src/general_plots/plot_erpgrid.jl
@@ -31,7 +31,7 @@ Plot an ERP image.
     Defaults: $(supportive_defaults(:labels_grid_default))
 - `indicator_grid_axis::NamedTuple = (;)`\\
     Here you can change configurations of inidcator axis.\\
-    Defaults: $(supportive_defaults(:indicator_grid_default))
+    Defaults: $(replace(string(supportive_defaults(:indicator_grid_default)), "_" => "\\_"))
 - `subaxes::NamedTuple = (;)`\\
     Here you can flexibly change configurations of all subaxes. F.e. make them wider or shorter\\
     To see all options just type `?Axis` in REPL.\\

--- a/src/general_plots/plot_topoplot.jl
+++ b/src/general_plots/plot_topoplot.jl
@@ -20,6 +20,10 @@ Plot a topoplot.
     Here you can flexibly change configurations of the topoplot interoplation.\\
     To see all options just type `?Topoplot.topoplot` in REPL.\\
     Defaults: $(replace(string(supportive_defaults(:topo_default_attributes; docstring = true)), "_" => "\\_"))
+- `return_objects::Bool = false`\\
+    Return a named tuple containing the created axis and colorbar.\\
+    Helpful for colorbar tweaking. If `false`, returns the figure.
+
 $(_docstring(:topoplot))
 
 To highlight some electrodes, you can use `topo_attributes = (; label_scatter = (; ...))`,  where `...` are the attributes for `scatter!` function.  For example, to change the marker size of all electrodes to 8,  use `topo_attributes = (; label_scatter = (; markersize = 15))`. 
@@ -56,6 +60,7 @@ function plot_topoplot!(
     positions = nothing,
     topo_attributes = (;),
     topo_axis = (;),
+    return_objects = false,
     kwargs...,
 )
 
@@ -125,6 +130,7 @@ Note: The identical min and max may cause an interpolation error when plotting t
             @lift config_kwargs!(config, colorbar = (; ticks = ($ticks, $rounded_ticks)))
         end
     end
+    cb = nothing
     if config.layout.use_colorbar
         cb_pos = if position == :right
             great_axis[plot_rows, plot_cols.stop+1]
@@ -158,5 +164,13 @@ Note: The identical min and max may cause an interpolation error when plotting t
         end
     end
     apply_layout_settings!(config; fig = f)
-    return f
+    return return_objects ?
+           (;
+        figure = f,
+        layout = great_axis,
+        axis = outer_axis,
+        topo_axis = inner_axis,
+        plot = h,
+        colorbar = cb,
+    ) : f
 end

--- a/test/test_circular_topoplots.jl
+++ b/test/test_circular_topoplots.jl
@@ -85,6 +85,19 @@ end
     )
 end
 
+@testset "circularplot return objects" begin
+    objects = plot_circular_topoplots(
+        df;
+        positions = pos,
+        predictor = :time,
+        predictor_bounds = [80, 320],
+        return_objects = true,
+    )
+    @test objects.figure isa Figure
+    @test objects.axis isa Axis
+    @test objects.colorbar isa Colorbar
+end
+
 @testset "circularplot horizontal colorbar positions" begin
     for position in (:top, :bottom)
         plot_circular_topoplots(

--- a/test/test_circular_topoplots.jl
+++ b/test/test_circular_topoplots.jl
@@ -85,6 +85,19 @@ end
     )
 end
 
+@testset "circularplot horizontal colorbar positions" begin
+    for position in (:top, :bottom)
+        plot_circular_topoplots(
+            df;
+            positions = pos,
+            center_label = "Visual angle [°]",
+            predictor = :time,
+            predictor_bounds = [80, 320],
+            colorbar = (; position),
+        )
+    end
+end
+
 @testset "circularplot plot in GridLayout with labels" begin
     f = Figure()
     ga = f[1, 1] = GridLayout()

--- a/test/test_topoplot.jl
+++ b/test/test_topoplot.jl
@@ -36,6 +36,18 @@ end
     plot_topoplot(dat[:, tp, 1]; positions = positions, layout = (; use_colorbar = false))
 end
 
+@testset "topoplot: return objects" begin
+    objects = plot_topoplot(
+        dat[:, tp, 1];
+        positions,
+        return_objects = true,
+    )
+    @test objects.figure isa Figure
+    @test objects.axis isa Axis
+    @test objects.topo_axis isa Axis
+    @test objects.colorbar isa Colorbar
+end
+
 @testset "topoplot: xlabel" begin
     plot_topoplot(dat[:, tp, 1]; positions = positions, axis = (; xlabel = "[$tp ms]"))
 end


### PR DESCRIPTION
- Example of montage with topoplotseries
- Solving alignment problem in complex plots + more sensible variable names
- Removing unused library calls
- Solving crossref problems
- Fix wrongly italised text in docstrings of plot_erpgrid
- Adding bottom and top positions for circular topopplot
- `return_objects` in plot_topoplot and plot_circularplot -> allows to change colorbar and figure after plotting

#419