### PR TITLE
Fix spline plots for multi-event models

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnfoldMakie"
 uuid = "69a5ce3b-64fb-4f22-ae69-36dd4416af2a"
 authors = ["Vladimir Mikheev", "Daniel Baumgartner", "Sören Döring", "Niklas Gärtner", "Furkan Lokman", "Benedikt Ehinger"]
-version = "0.5.25"
+version = "0.5.26"
 
 [deps]
 AlgebraOfGraphics = "cbdf2221-f076-402e-a563-3d30da359d67"

--- a/src/unfold_plots/plot_splines.jl
+++ b/src/unfold_plots/plot_splines.jl
@@ -44,22 +44,30 @@ function plot_splines!(
 
     ga = f[1, 1] = GridLayout()
 
-    terms = reduce(vcat, Unfold.terms.(getfield.(Unfold.formulas(m), :rhs)))
-    spl_title = join(terms, " + ")
+    terms_by_event = Unfold.terms.(getfield.(Unfold.formulas(m), :rhs))
+    # Show only spline-containing formulas and omit duplicated display terms.
+    spline_event_terms = filter(
+        event_terms -> any(term -> term isa Unfold.AbstractSplineTerm, event_terms),
+        terms_by_event,
+    )
+    @assert !isempty(spline_event_terms) "No spline term is found in UnfoldModel. Does your UnfoldModel really have a `spl(...)` or other `AbstractSplineTerm`?"
+    spl_title = join(unique(reduce(vcat, spline_event_terms)), " + ")
 
     splFunction = Base.get_extension(Unfold, :UnfoldBSplineKitExt).splFunction
-    spl_ix = findall(isa.(terms, Unfold.AbstractSplineTerm))
-    @assert !isempty(spl_ix) "No spline term is found in UnfoldModel. Does your UnfoldModel really have a `spl(...)` or other `AbstractSplineTerm`?"
-
-    spline_terms = [terms[i] for i in spl_ix]
-    subplot_id = 1
-    for spline_term in spline_terms
+    # Keep each spline paired with its event table so its predictor comes from the correct event.
+    spline_terms_and_events = [
+        (term, event) for (event_terms, event) in
+        zip(terms_by_event, Unfold.events(designmatrix(m))) for term in event_terms if
+        term isa Unfold.AbstractSplineTerm
+    ]
+    for (subplot_id, (spline_term, event)) in enumerate(spline_terms_and_events)
         x_range = range(
-            spline_term.breakpoints[1],
-            stop = spline_term.breakpoints[end],
+            first(spline_term.breakpoints),
+            last(spline_term.breakpoints);
             length = 100,
         )
         basis_set = splFunction(x_range, spline_term)
+        basis_curves = basis_set'
 
         if subplot_id > 1
             spline_axis = update_axis(spline_axis; ylabelvisible = false)
@@ -67,25 +75,25 @@ function plot_splines!(
         end
         a1 = Axis(ga[1, subplot_id]; title = string(spline_term), spline_axis...)
         series!(
+            a1,
             x_range,
-            basis_set',
-            color = resample_cmap(config.visual.colormap, size(basis_set')[1]),
+            basis_curves,
+            color = resample_cmap(config.visual.colormap, size(basis_curves, 1)),
         ) # continuous color map used
         vlines!(
+            a1,
             spline_term.breakpoints;
-            ymin = extrema(basis_set')[1],
-            ymax = extrema(basis_set')[2],
             linestyle = :dash,
         )
         a2 = Axis(ga[2, subplot_id]; xlabel = string(spline_term.term.sym), density_axis...)
         density!(
-            Unfold.events(designmatrix(m))[1][:, spline_term.term.sym];
+            a2,
+            event[!, spline_term.term.sym];
             color = :transparent,
             strokecolor = :black,
             strokewidth = 1,
         )
         linkxaxes!(a1, a2)
-        subplot_id = subplot_id + 1
     end
     Label(ga[1, 1:end, Top()], spl_title; superlabel_config...)
     apply_layout_settings!(config; fig = f)

--- a/test/test_splines.jl
+++ b/test/test_splines.jl
@@ -4,6 +4,13 @@ m1 = UnfoldMakie.example_data("UnfoldLinearModelwith1Spline")
 m2 = UnfoldMakie.example_data("UnfoldLinearModelwith2Splines")
 m3 = UnfoldMakie.example_data("UnfoldLinearModelwith1SplineSecondPlace")
 
+# to verife correctness of the superlabel
+spline_superlabel(f) = only(filter(content -> content isa Label, f.content))
+spline_superlabel_text(f) = spline_superlabel(f).text[]
+const ONE_SPLINE_TITLE = "1 + condition + spl(continuous, 4)"
+const TWO_SPLINES_TITLE =
+    "1 + condition + spl(continuous, 4) + spl(continuous2, 6)"
+
 @testset "Spline plot: no splines" begin
     err1 = nothing
     t() = error(plot_splines(m0))
@@ -17,29 +24,36 @@ m3 = UnfoldMakie.example_data("UnfoldLinearModelwith1SplineSecondPlace")
 end
 
 @testset "Spline plot: basic" begin
-    plot_splines(m1)
+    f = plot_splines(m1)
+    @test spline_superlabel_text(f) == ONE_SPLINE_TITLE
 end
 
 
 @testset "Spline plot: GridLayout" begin
     f = Figure()
     plot_splines!(f, m1)
+    @test spline_superlabel_text(f) == ONE_SPLINE_TITLE
 end
 
 @testset "Spline plot: two spline terms" begin
-    plot_splines(m2)
+    f = plot_splines(m2)
+    @test spline_superlabel_text(f) == TWO_SPLINES_TITLE
 end
 
 @testset "Spline plot: spline_axis check" begin
-    plot_splines(m2; spline_axis = (; ylabel = "test"))
+    f = plot_splines(m2; spline_axis = (; ylabel = "test"))
+    @test spline_superlabel_text(f) == TWO_SPLINES_TITLE
 end
 
 @testset "Spline plot: density_axis check" begin
-    plot_splines(m2, density_axis = (; ylabel = "test"))
+    f = plot_splines(m2, density_axis = (; ylabel = "test"))
+    @test spline_superlabel_text(f) == TWO_SPLINES_TITLE
 end
 
 @testset "Spline plot: superlabel_axis check" begin
-    plot_splines(m2; superlabel_config = (; fontsize = 60))
+    f = plot_splines(m2; superlabel_config = (; fontsize = 60))
+    @test spline_superlabel_text(f) == TWO_SPLINES_TITLE
+    @test spline_superlabel(f).fontsize[] == 60
 end
 
 @testset "Spline plot: backgroundcolor" begin
@@ -50,8 +64,10 @@ end
         spline_axis = (; backgroundcolor = colorant"#F4F3EF"),
         density_axis = (; backgroundcolor = colorant"#F4F3EF"),
     )
+    @test spline_superlabel_text(f) == ONE_SPLINE_TITLE
 end
 
-@testset "Spline plot: spline on the second place" begin
-    plot_splines(m3)
+@testset "Spline plot: spline in second event formula" begin
+    f = plot_splines(m3)
+    @test spline_superlabel_text(f) == "1 + spl(continuous, 5)"
 end


### PR DESCRIPTION
Fixes event-specific spline predictor selection and superlabel generation. Adds regression coverage for splines in the second event formula.
#375